### PR TITLE
Fix `#within_interval` readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ employee.employee_assignments.within_date(Date.tomorrow)
 ```
 
 ```ruby
-employee.employee_assignments.within_interval(Date.current.beginning_of_month...Date.current.end_of_month)
+employee.employee_assignments.within_interval(Date.current.beginning_of_month, Date.current.end_of_month)
 ```
 
 Look up records starting with specific date with `from_date`


### PR DESCRIPTION
Looks like we don't use range as argument for `#within_interval` (https://github.com/mitigate-dev/periodic_records/blob/master/lib/periodic_records/model.rb#L17), but instead provide two arguments start & end date.